### PR TITLE
Fix riproduzione video su Kodi 18

### DIFF
--- a/default.py
+++ b/default.py
@@ -44,6 +44,8 @@ def addDirectoryItem(parameters, li):
 def addLinkItem(parameters, li, url=""):
     if url == "":
         url = sys.argv[0] + '?' + urllib.urlencode(parameters)
+    li.setProperty('IsPlayable', 'true')
+    li.setInfo("video", {})
     return xbmcplugin.addDirectoryItem(handle=handle, url=url, 
         listitem=li, isFolder=False)
 
@@ -108,7 +110,6 @@ def show_tgr_list(mode, url):
                 "url": item["url"]}, liStyle)
         else:
             liStyle = xbmcgui.ListItem(item["title"])
-            liStyle.setProperty('IsPlayable', 'true')
             addLinkItem({"mode": "play",
                 "url": item["url"]}, liStyle)            
     xbmcplugin.endOfDirectory(handle=handle, succeeded=True)
@@ -158,7 +159,6 @@ def show_tv_channels():
     raiplay = RaiPlay()
     for station in tv_stations:
         liStyle = xbmcgui.ListItem(station["channel"], thumbnailImage=raiplay.getThumbnailUrl(station["transparent-icon"]))
-        liStyle.setProperty('IsPlayable', 'true')
         addLinkItem({"mode": "play",
             "url": station["video"]["contentUrl"]}, liStyle)
     xbmcplugin.endOfDirectory(handle=handle, succeeded=True)
@@ -167,7 +167,6 @@ def show_radio_stations():
     for station in radio_stations:
         if station["flussi"]["liveAndroid"] != "":
             liStyle = xbmcgui.ListItem(station["nome"], thumbnailImage="http://www.rai.it" + station["chImage"])
-            liStyle.setProperty('IsPlayable', 'true')
             addLinkItem({"mode": "play",
                 "url": station["flussi"]["liveAndroid"]}, liStyle)
     xbmcplugin.endOfDirectory(handle=handle, succeeded=True)
@@ -225,12 +224,10 @@ def show_replay_epg(channelId, date):
             # programme is not available
             liStyle = xbmcgui.ListItem(startTime + " [I]" + title + "[/I]",
                 thumbnailImage=thumb)
-            liStyle.setProperty('IsPlayable', 'true')
             addLinkItem({"mode": "nop"}, liStyle)
         else:
             liStyle = xbmcgui.ListItem(startTime + " " + title,
                 thumbnailImage=thumb)
-            liStyle.setProperty('IsPlayable', 'true')
             addLinkItem({"mode": "play",
                 "path_id": videoUrl}, liStyle)
     xbmcplugin.endOfDirectory(handle=handle, succeeded=True)
@@ -287,7 +284,6 @@ def show_ondemand_programme(pathId):
     if programme["infoProg"]["tipologia"][0]["nome"] == "Film":
         if "pathFirstItem" in programme:
             liStyle = xbmcgui.ListItem(programme["infoProg"]["name"], thumbnailImage=raiplay.getThumbnailUrl(programme["infoProg"]["images"]["landscape"]))
-            liStyle.setProperty('IsPlayable', 'true')
             addLinkItem({"mode": "play",
                 "path_id": programme["pathFirstItem"]}, liStyle)
     else:
@@ -307,7 +303,6 @@ def show_ondemand_items(url):
         if "subtitle" in item and item["subtitle"] != "" and item["subtitle"] != item["name"]:
             title = title + " (" + item["subtitle"] + ")"
         liStyle = xbmcgui.ListItem(title, thumbnailImage=raiplay.getThumbnailUrl(item["images"]["landscape"]))
-        liStyle.setProperty('IsPlayable', 'true')
         addLinkItem({"mode": "play",
             "path_id": item["pathID"]}, liStyle)
     xbmcplugin.endOfDirectory(handle=handle, succeeded=True)
@@ -364,7 +359,6 @@ def show_search_result(items):
     
     for item in items:
         liStyle = xbmcgui.ListItem(item["name"], thumbnailImage=raiplay.getThumbnailUrl(item["images"]["landscape"]))
-        liStyle.setProperty('IsPlayable', 'true')
         addLinkItem({"mode": "play", "path_id": item["PathID"]}, liStyle)
 
     xbmcplugin.addSortMethod(handle, xbmcplugin.SORT_METHOD_NONE)

--- a/resources/lib/raiplay.py
+++ b/resources/lib/raiplay.py
@@ -69,7 +69,7 @@ class RaiPlay:
         return response["video"]
     
     def getUrl(self, pathId):
-        pathId = pathId.replace(" ", "%20")
+        pathId = urllib2.unquote(pathId)
         if pathId[0:2] == "//":
             url = "http:" + pathId
         elif pathId[0] == "/":


### PR DESCRIPTION
- ListItem richiede che sia specificato la tipologia del contenuto su Kodi 18
- Bugfix per le url di RaiReplay